### PR TITLE
Fix build with GCC 13

### DIFF
--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -21,6 +21,8 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef _DTAOPTIONS_H
 #define	_DTAOPTIONS_H
 
+#include <stdint.h>
+
 /** Output modes */
 typedef enum _sedutiloutput {
 	sedutilNormal,


### PR DESCRIPTION
As in previous versions, libstdc++ in GCC 13 has trimmed internal inclusion of standard headers, necessitating their proper inclusion when used:

https://gcc.gnu.org/gcc-13/porting_to.html